### PR TITLE
feat: Redirection 301 url incubateur to fabrique

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,17 @@ Deploy app (prod):
     name: prod
     url: https://www.${KUBE_INGRESS_BASE_DOMAIN}
 
+Deploy incubateur redirect pod (prod):
+  extends: .base_docker_kubectl_image_stage
+  variables:
+    K8S_NAMESPACE: www
+    PRODUCTION: "true"
+    script:
+      - echo "kubectl get namespace ${K8S_NAMESPACE}"
+      - kubectl apply -f .k8s/redirect.yml -n ${K8S_NAMESPACE}
+  environment:
+    name: prod
+
 #
 
 Delete useless k8s namespaces:

--- a/.k8s/redirect.yml
+++ b/.k8s/redirect.yml
@@ -32,7 +32,6 @@ spec:
               value: "301"
           ports:
             - containerPort: 80
-          #              protocol: TCP
           readinessProbe:
             failureThreshold: 3
             httpGet:

--- a/.k8s/redirect.yml
+++ b/.k8s/redirect.yml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redirect-incubateur
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redirect-incubateur
+  template:
+    metadata:
+      labels:
+        app: redirect-incubateur
+    spec:
+      containers:
+        - image: pindar/docker-nginx-redirect-301
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 80
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: redirect-incubateur
+          env:
+            - name: REDIRECT_URL
+              value: "https://fabrique.social.gouv.fr"
+            - name: REDIRECT_CODE
+              value: "301"
+          ports:
+            - containerPort: 80
+          #              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 80
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 50m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redirect-incubateur
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: redirect-incubateur
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+  name: redirect-incubateur
+spec:
+  rules:
+    - host: incubateur.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              serviceName: redirect-incubateur
+              servicePort: 80
+    - host: www.incubateur.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              serviceName: redirect-incubateur
+              servicePort: 80
+  tls:
+    - hosts:
+        - incubateur.social.gouv.fr
+        - www.incubateur.social.gouv.fr
+      secretName: incubateur-crt

--- a/.k8s/redirect.yml
+++ b/.k8s/redirect.yml
@@ -27,7 +27,7 @@ spec:
           name: redirect-incubateur
           env:
             - name: REDIRECT_URL
-              value: "https://fabrique.social.gouv.fr"
+              value: "https://www.fabrique.social.gouv.fr"
             - name: REDIRECT_CODE
               value: "301"
           ports:


### PR DESCRIPTION
Déploiement d'un pod dans le namspace www
Le POD réalise les redirections type 301 des urls:
- incubateur.social.gouv.fr
- www.incubateur.social.gouv.fr

vers:
- https://www.fabrique.social.gouv.fr

https://gitlab.factory.social.gouv.fr/SocialGouv/documentation/issues/78

Avant de déployer il faudra supprimer le POD en place déployer manuellement.

Le POD pour la redirection n'est à déployer que sur la PROD. Faut-il ajouter dans le code cette notion. Si c'est cas ou dois-je le faire apparaitre.