### PR TITLE
feat: add yarn run beta-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint src pages",
     "rss": "node ./scripts/rss.js > ./out/feed.xml",
     "github-stats": "node ./scripts/github-stats.js > ./public/github-stats.json",
+    "beta-sync": "node ./scripts/beta-sync.js",
     "k8s": "yarn --silent --cwd .k8s"
   },
   "devDependencies": {

--- a/pages/startups/archifiltre.mdx
+++ b/pages/startups/archifiltre.mdx
@@ -1,16 +1,20 @@
 import { BlocCards, LayoutArticle, StartupMembers } from "../../src/composants";
 
 export const meta = {
-title: "Vos arborescences de fichiers bureautiques comme vous ne les avez jamais vues",
-hero: {
-background: "/images/startups/todd-trapani-1054329-unsplash.jpg",
-alt: "Photo by Harli Marten",
-title: "Archifiltre",
-tagline: "Vos arborescences de fichiers bureautiques comme vous ne les avez jamais vues"
-}
+  title:
+    "Vos arborescences de fichiers bureautiques comme vous ne les avez jamais vues",
+  hero: {
+    background: "/images/startups/todd-trapani-1054329-unsplash.jpg",
+    alt: "Photo by Harli Marten",
+    title: "Archifiltre",
+    tagline:
+      "Vos arborescences de fichiers bureautiques comme vous ne les avez jamais vues",
+  },
 };
 
 <LayoutArticle meta={meta} startup="archifiltre">
+
+<!-- start content -->
 
 ## Nos origines
 
@@ -39,5 +43,7 @@ L’outil sur lequel nous travaillons dans le cadre de la startup devra approfon
 Cette démarche doit également tenir compte de l’intégration du produit ArchiFiltre dans un écosystème en cours de construction autour de l’archivage électronique des données publiques.
 
 Nous contacter: archifiltre@sg.social.gouv.fr
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/archifiltre.mdx
+++ b/pages/startups/archifiltre.mdx
@@ -16,33 +16,35 @@ export const meta = {
 
 <!-- start content -->
 
-## Nos origines
+# Le contexte
 
-Dans toutes les organisations, la dette de documents numériques produits et non triés augmente de manière exponentielle et incontrôlée. L’absence de représentation visuelle de ces masses de documents amène tout producteur de fichiers bureautiques à continuer à stocker, sans parfois en maîtriser le contenu, des strates et des strates de fichiers. Cette accumulation souvent anarchique s’accentue avec l’utilisation de serveurs de fichiers partagés dont la capacité de stockage augmente au fur et à mesure que les coûts de stockage diminuent.
-Les archivistes des ministères sociaux étant confrontés à cette production de documents de manière particulièrement accrue depuis quelques années, elle.il.s ont voulu se doter d’un outil pour leur permettre de relever le défi du tri et de la description de ces arborescences de fichiers.
-C’est dans le cadre de cette réflexion qu’ArchiFiltre a démarré en 2018 grâce au soutien d’Etalab dans le cadre de la 2ème promotion du programme EIG (Entrepreneur.e.s d’intérêt général) pour 10 mois de développement (Voir https://entrepreneur-interet-general.etalab.gouv.fr/defis/2018/archifiltre.html pour davantage d’informations). Depuis le mois de mars 2019, ArchiFiltre a rejoint la fabrique numérique des ministères sociaux et est devenue une startup d'État pour poursuivre les travaux entamés.
+Depuis quelques années, la généralisation des outils informatiques et la multiplication des outils de partage et de stockage contribuent à une explosion de la production de fichiers bureautiques. 
 
-## Nos objectifs
+# Le problème
 
-L’objectif d’ArchiFiltre est de proposer à tout utilisateur de fichiers bureautiques un outil de visualisation d’arborescences complètes afin de pouvoir les appréhender rapidement en vue de les décrire, les organiser, les trier et aussi les enrichir en apportant de la contextualisation et de la qualification aux documents.
-Pour les utilisateurs de profil archiviste, l’outil permet de réaliser à la fin du traitement un paquet au format SEDA (standard d’échange de données pour l’archivage), format d’entrée des documents et leurs métadonnées dans un système d’archivage électronique.
-Pour les utilisateurs de profil producteur de documents, l’outil est une aide à la compréhension à un niveau macro d’arborescences complètes de fichiers pour pouvoir mieux les comprendre, les maîtriser et donc les gérer.
-Notre objectif est simple… Sauver le monde de l’information bureautique!
+Face à ces volumes dont l'ampleur est difficile à matérialiser, les organisations ne réalisent pas l'accumulation et l'engorgement, sur les serveurs, de fichiers très anciens voire obsolètes pour lesquels elles ne savent de toutes façons pas réaliser de tri.
 
-## Nos réalisations
+Les conséquences peuvent être de différents ordres pour les agents des administrations: 
+- des espaces serveur surchargés qui coûtent inutilement en terme de stockage (coût financier et écologique), 
+- une grande difficulté à retrouver des documents perdus dans une organisation difficile à comprendre et souvent redondante
+- un risque juridique à ne pas retrouver l'information pour les besoins de l'administration ou des citoyens 
+- une conservation de données qui devraient être détruites depuis longtemps.
 
-L’outil déjà développé est un outil libre et ouvert, disponible sur https://archifiltre.fabrique.social.gouv.fr/. La v10 est la dernière version aboutie de l’outil qui s’exécute en local. La v8 fonctionne, elle, sur navigateur Internet (Chrome de préférence). Ces deux versions continueront à exister et à être enrichies de nouvelles fonctionnalités en parallèle car elles répondent à la diversité des utilisateurs en terme d’équipements informatiques.
+# Notre cible
 
-## Nos utilisateurs
+Les professionnel·le·s de l'information (dont environ 5000 archivistes exerçant dans le secteur public) ont pour mission de traiter cette production exponentielle. Sans outil adapté, ils/elles étaient dans l'incapacité d'appréhender et donc de traiter ces volumes d'information pourtant potentiellement stratégique. Leur intervention consiste à évaluer la pertinence de l'information et ainsi trier, améliorer des arborescences de fichiers mais également accompagner les agents dans la réorganisation ou encore la recherche de leurs documents.
 
-ArchiFiltre est un produit imaginé pour correspondre aux besoins des ministères sociaux mais aussi à ceux d’un réseau large et dynamique d’archivistes présents tant dans le secteur public que privé. Les développements réalisés en 2018 ont associé de nombreux utilisateurs, archivistes principalement, issus de ministères, établissements publics, collectivités territoriales ou entreprises. La priorisation des développements est donc basée sur ce réseau d’utilisateurs coordonné par le bureau des archives des ministères sociaux mais nous souhaitons également associer davantage d’autres profils et d’autres archivistes, l’appréhension d’arborescences de fichiers concernant tout producteur de documents bureautiques.
+# Notre solution
 
-## Nos prochains développements
+Nous avons conçu un outil de visualisation permettant de comprendre puis d'enrichir des arborescences de fichiers, de réaliser des audits, des réorganisations, d'identifier des doublons et de pouvoir exporter son travail dans des formats modifiables et interopérables.
 
-L’outil sur lequel nous travaillons dans le cadre de la startup devra approfondir les fonctionnalités proposées dans les 1ères versions mises en ligne: améliorer les performances pour permettre des analyses de volumes de fichiers plus importants (au-delà de 250 Go), proposer d’autres types de visualisation (à plat ou en pondérant l’importance des fichiers différemment), améliorer la visualisation existante (pour les éléments de petit volume par exemple), prendre en compte les demandes d’amélioration de l’UX/UI, élargir les fonctionnalités actuellement disponibles dans l’outil (comme le taggage, le lien avec des référentiels et l’ajout de certaines métadonnées). L’objectif est maintenant de proposer de nouvelles versions régulières de cet outil pendant l’année 2019 en continuant de prendre en compte les besoins exprimés par les utilisateurs et en améliorant également l’animation du réseau des utilisateurs.
-Cette démarche doit également tenir compte de l’intégration du produit ArchiFiltre dans un écosystème en cours de construction autour de l’archivage électronique des données publiques.
+Avec Archifiltre, il est désormais possible d'auditer puis d'identifier les tris à réaliser sur un serveur, de réaliser un plan de classement efficace et également de préparer les paquets de documents à conserver en archivage au format adéquat.
 
-Nous contacter: archifiltre@sg.social.gouv.fr
+# Notre stratégie
+
+Notre stratégie, depuis les débuts, est de développer un outil libre, gratuit, au maximum intuitif afin de rendre son utilisation possible par tou·te·s, y compris les professionnel·le·s de l'information. Des versions sont proposées régulièrement au téléchargement (environ tous les 2 à 3 mois), testées avec les utilisateur·trice·s et augmentées de fonctionnalités au fur et à mesure. 
+
+Par ailleurs, la priorisation a toujours été réalisée à partir des demandes d'utilisateur·trice·s issu·e·s de contextes très variés qui permettent de vérifier, en permanence, que les fonctionnalités développées sont adaptées au plus grand nombre (tant dans les administrations de l'Etat que dans les collectivités, chez des opérateurs nationaux ou locaux, comme dans des entreprises ou des associations) grâce aux nombreux retours utilisateurs reçus lors des openlabs et sessions d'échanges (présentations, webinaires, communication réalisée lors des sorties de versions) ou encore via le questionnaire mis en place pour recueillir les attentes.
 
 <!-- end content -->
 

--- a/pages/startups/didoc.mdx
+++ b/pages/startups/didoc.mdx
@@ -6,11 +6,14 @@ export const meta = {
     background: "/images/startups/bill-oxford-tR0PPLuN6Pw-unsplash.jpg",
     alt: "Photo by Bill Oxford on Unsplash",
     title: "DIDOC",
-    tagline: "Dématérialisation des Invitations au Dépistage Organisé des Cancers"
-  }
+    tagline:
+      "Dématérialisation des Invitations au Dépistage Organisé des Cancers",
+  },
 };
 
 <LayoutArticle meta={meta} startup="didoc">
+
+<!-- start content -->
 
 ## Contexte
 
@@ -37,7 +40,7 @@ Nous souhaitons travailler sur ces raisons pratiques en simplifiant le processus
 
 Notre objectif est de dématérialiser l'invitation au dépistage qui est aujourd'hui réalisée uniquement par courrier.
 
-En utilisant un envoi d'email, nous pourrons simplifier le processus de différentes manières :
+En utilisant un envoi d'email, nous pourrons simplifier le processus de différentes manières : 
 - Moins de NPAI (n'habite pas à l'adresse indiquée) car les adresses email sont moins susceptibles d'être modifiées que les adresses postales.
 - Prise de rendez-vous directe à la suite de la réception de l'email grâce aux systèmes de réservation en ligne des radiologues ou par téléphone en s'appuyant sur la géolocalisation des cabinets de radiologie les plus proches proposée en ligne par l'intermédiaire d'une carte.
 
@@ -57,5 +60,6 @@ Ce test est une première expérimentation. Si les résultats s'avèrent conclua
 
 En Côte-d'Or, 59,6% des femmes participent au dépistage. L'objectif à atteindre serait l'augmentation de cette participation d'au minimum de 2% pour la population recevant l'invitation par voie dématérialisée. Cela représente 700 dépistages en plus chaque année en Côte-d'Or uniquement.
 
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/domifa.mdx
+++ b/pages/startups/domifa.mdx
@@ -14,8 +14,9 @@ export const meta = {
 
 <LayoutArticle meta={meta} startup="domifa">
 
+<!-- start content -->
 
-## Qu’est-ce que la domiciliation ?
+## Qu’est-ce que la domiciliation ? 
 
 **La domiciliation est un premier pas vers l’accès aux droits des personnes sans domicile stable.**
 Elle leur permet de disposer d'une adresse administrative où recevoir leur courrier et de faire valoir leurs droits civils, civiques et sociaux (comme la délivrance d’un titre national d’identité, l’inscription sur les listes électorales, l’accès à des aides sociales…).
@@ -26,9 +27,9 @@ Cette attestation est valable un an. Elle est soumise à la manifestation régul
 
 ## Un processus complexe qui pose des problèmes de prise en charge
 
-**Le processus de domiciliation pose plusieurs difficultés liées à l’absence d’outil de suivi commun.** Du point de vue des structures, il est chronophage et se résume pour l’essentiel à des tâches de gestion des courriers comme des domiciliations.
+**Le processus de domiciliation pose plusieurs difficultés liées à l’absence d’outil de suivi commun.** Du point de vue des structures, il est chronophage et se résume pour l’essentiel à des tâches de gestion des courriers comme des domiciliations. 
 
-Certaines structures rencontrent également d’important problème de surcharge avec une augmentation continue du nombre de demandes.
+Certaines structures rencontrent également d’important problème de surcharge avec une augmentation continue du nombre de demandes. 
 
 ## DomiFa : une Startup d’Etat qui permet de sécuriser le processus de domiciliation et de libérer du temps pour l’accompagnement social
 
@@ -39,22 +40,21 @@ La solution permet actuellement de dématérialiser une partie de la procédure 
 ## Quelles sont les fonctionnalités disponibles sur DomiFa ?
 
 DomiFa permet aux structures de réaliser les fonctionnalités qui sont au cœur de la domiciliation :
-
 - Instruction et validation des demandes
-- Enregistrement des passages et des interactions
+- Enregistrement des passages et des interactions 
 - Suivi du courrier reçu et distribué
 - Gestion des domiciliations et des échéances associées
 
-A plus long terme, la solution intégrera d’autres services (communication avec les domiciliés, gestion des courriers, recherche statistiques…).
+A plus long terme, la solution intégrera d’autres services (communication avec les domiciliés, gestion des courriers, recherche statistiques…). 
 
 ## Comment fonctionne DomiFa ?
 
 **DomiFa est un outil numérique permettant aux organismes domiciliataires de simplifier la gestion de la domiciliation des personnes sans domicile stable.**
 
-La facilité d’utilisation et la sécurité sont primordiales pour DomiFa.
+La facilité d’utilisation et la sécurité sont primordiales pour DomiFa. 
 DomiFa est accessible via une plateforme Web sécurisée sur Google Chrome ou Firefox et est disponible gratuitement. Aucun logiciel supplémentaire n’est à installer. La connexion est personnelle et confidentielle : seules les personnes autorisées ayant créé un compte utilisateur ont accès à son contenu et aux informations personnelles concernant les domiciliés de leur structure.
 
-## Vous souhaitez rejoindre DomiFa ?
+##  Vous souhaitez rejoindre DomiFa ?
 
 Vous êtes un CCAS, un CIAS, une association agréée réalisant de la domiciliation ?
 
@@ -62,5 +62,6 @@ Vous souhaitez vous inscrire sur DomiFa ? Obtenir des renseignements sur la plat
 
 **[Contactez-nous](mailto:contact.domifa@fabrique.social.gouv.fr)**
 
-</LayoutArticle>
+<!-- end content -->
 
+</LayoutArticle>

--- a/pages/startups/e-mjpm.mdx
+++ b/pages/startups/e-mjpm.mdx
@@ -6,26 +6,39 @@ export const meta = {
     background: "/images/startups/harli-marten-135841-unsplash.jpg",
     alt: "Photo by Harli Marten",
     title: "e-MJPM",
-    tagline: "Trouver rapidement le bon professionnel pour les majeurs à protéger"
-  }
+    tagline:
+      "Trouver rapidement le bon professionnel pour les majeurs à protéger",
+  },
 };
 
 <LayoutArticle meta={meta} startup="e-mjpm">
 
-Aujourd'hui, la France compte **entre 800 000 et 1 million de personnes sous mesure de protection** (tutelle, curatelle, sauvegarde de justice). Chaque année plusieurs milliers de personnes majeures sont nouvellement concernés.
+<!-- start content -->
 
-Ces dernières, dans l'impossibilité de pourvoir seules à leurs intérêts (à cause d'une altération de leur faculté mentale ou corporelle) ont besoin d'être assistées ou représentées par un proche ou un professionnel.
+## Simplifier la relation entre les Juges de Tutelles et professionnels de la protection juridique des majeurs
 
-Aujourd'hui les juges attribuent les mesures de protection sans avoir connaissance en temps réel de l'activité des travailleurs sociaux et de leur zone d'intervention géographique. La personne à protéger n'a donc pas systématiquement une prise en charge optimale.
+La France compte entre 800 000 et 1 million de personnes sous mesure de protection (tutelle, curatelle, sauvegarde de justice). Chaque année plusieurs milliers de personnes majeures sont nouvellement concernés. Ces dernières, dans l’impossibilité de pourvoir seules à leurs intérêts (à cause d’une altération de leur faculté mentale ou corporelle) ont besoin d’être assistées ou représentées par un proche ou un professionnel.
 
-Concrètement un travailleur social peut passer trop de temps pour se rendre chez la personne au détriment de son accompagnement. Un professionnel surchargé peut être mobilisé pour un accompagnement alors qu'un homologue plus près de la personne serait disponible…
+Aujourd'hui, les juges attribuent les mesures de protection sans avoir connaissance en temps réel de l’activité des travailleurs sociaux et de leur zone d’intervention géographique. La personne à protéger n’a donc pas systématiquement une prise en charge optimale : un travailleur social peut passer trop de temps pour se rendre chez la personne au détriment de son accompagnement, un professionnel surchargé peut être mobilisé pour un accompagnement alors qu’un homologue plus près de la personne serait disponible.
 
-Avec e-MJPM, le magistrat pourra **choisir au mieux le professionnel qui sera en charge de la mesure** (tutelle, curatelle, sauvegarde de justice) sur la base d'un référentiel géolocalisé des mandataires.
+Le rapport de la Cour des Comptes 2016 sur la protection juridique des majeurs confirme l’insuffisance des outils actuels dans la gestion des mesures de protection.
 
-Ce service consolidera ainsi une base de données des mesures en cours sur le territoire. Ces données ont une valeur essentielle dans le pilotage de la politique publique de la protection juridique des majeurs (connaître le profil des personnes sous protection, adapter l'offre des mandataires aux spécificités du territoire, …).
+## e-MJPM : Trouver rapidement le bon professionnel pour les majeurs à protéger
 
-Le service numérique a été testé dans un premier temps sur le Nord Pas de Calais en associant les magistrats et les professionnels mobilisés. **Le déploiement sera engagé au fur et à mesure** sur de nouveaux territoires, en partenariat avec le ministère de la Justice.
+Avec e-mjpm, le magistrat peut choisir au mieux le professionnel qui sera en charge de la mesure (tutelle, curatelle, sauvegarde de justice) sur la base d’un référentiel géolocalisé des tuteurs. Pour faciliter la mise en place de la mesure, il peut éventuellement notifier en direct sa décision.
 
-Le rapport de la Cour des Comptes 2016 sur la protection juridique des majeurs confirme l'**insuffisance des outils actuels dans la gestion des mesures de protection**.
+<div class="video-iframe-center">
+  <div class="video-iframe-container">
+    <iframe src="https://www.dailymotion.com/embed/video/x6z9qkc" allowfullscreen></iframe>
+  </div>
+</div>
+
+Ce service consolide ainsi une base de données des mesures en cours sur le territoire. Ces données ont une valeur essentielle dans le pilotage de la politique publique de la protection juridique des majeurs (connaître le profil des personnes sous protection, adapter l’offre des tuteurs aux spécificités du territoire, identifier les mesures familiales et adapter l’information et le soutien proposé…).
+
+Le service numérique est aujourd'hui déployé sur le département des Hauts de France et Paris. Le déploiement sera engagé au fur et à mesure sur de nouveaux territoires, en partenariat avec le ministère de la Justice.
+
+e-MJPM est une première réponse pour une meilleure gestion des mesures de protection et a pour objectif de simplifier à terme toutes les démarches des personnes sous protection.
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/e-mjpm.mdx
+++ b/pages/startups/e-mjpm.mdx
@@ -15,7 +15,7 @@ export const meta = {
 
 <!-- start content -->
 
-## Simplifier la relation entre les Juges de Tutelles et professionnels de la protection juridique des majeurs
+### Simplifier la relation entre les magistrats et professionnels de la protection juridique des majeurs
 
 La France compte entre 800 000 et 1 million de personnes sous mesure de protection (tutelle, curatelle, sauvegarde de justice). Chaque année plusieurs milliers de personnes majeures sont nouvellement concernés. Ces dernières, dans l’impossibilité de pourvoir seules à leurs intérêts (à cause d’une altération de leur faculté mentale ou corporelle) ont besoin d’être assistées ou représentées par un proche ou un professionnel.
 
@@ -23,21 +23,15 @@ Aujourd'hui, les juges attribuent les mesures de protection sans avoir connaissa
 
 Le rapport de la Cour des Comptes 2016 sur la protection juridique des majeurs confirme l’insuffisance des outils actuels dans la gestion des mesures de protection.
 
-## e-MJPM : Trouver rapidement le bon professionnel pour les majeurs à protéger
+### e-MJPM : trouver rapidement le bon professionnel pour les majeurs à protéger
 
-Avec e-mjpm, le magistrat peut choisir au mieux le professionnel qui sera en charge de la mesure (tutelle, curatelle, sauvegarde de justice) sur la base d’un référentiel géolocalisé des tuteurs. Pour faciliter la mise en place de la mesure, il peut éventuellement notifier en direct sa décision.
-
-<div class="video-iframe-center">
-  <div class="video-iframe-container">
-    <iframe src="https://www.dailymotion.com/embed/video/x6z9qkc" allowfullscreen></iframe>
-  </div>
-</div>
+Avec e-MJPM, le magistrat peut choisir au mieux le professionnel qui sera en charge de la mesure sur la base d’un référentiel de mandataires contrôlé et validé par les agents du ministère. 
 
 Ce service consolide ainsi une base de données des mesures en cours sur le territoire. Ces données ont une valeur essentielle dans le pilotage de la politique publique de la protection juridique des majeurs (connaître le profil des personnes sous protection, adapter l’offre des tuteurs aux spécificités du territoire, identifier les mesures familiales et adapter l’information et le soutien proposé…).
 
-Le service numérique est aujourd'hui déployé sur le département des Hauts de France et Paris. Le déploiement sera engagé au fur et à mesure sur de nouveaux territoires, en partenariat avec le ministère de la Justice.
+Avec e-MJPM, les mandataires ont un suivi en temps réel des mesures qui leur ont été assignés par les magistrats. 
 
-e-MJPM est une première réponse pour une meilleure gestion des mesures de protection et a pour objectif de simplifier à terme toutes les démarches des personnes sous protection.
+Le produit est aujourd'hui déployé et utilisé sur le département des Hauts de France et Paris et poursuit sont déploiement sur tout le territoire national, en partenariat avec le ministère de la Justice.
 
 <!-- end content -->
 

--- a/pages/startups/egapro.mdx
+++ b/pages/startups/egapro.mdx
@@ -7,11 +7,13 @@ export const meta = {
     alt: "Photo by Tim Mossholder",
     title: "Egapro",
     tagline:
-      "L’outil de calcul de votre index égalité professionnelle Femmes-Hommes"
-  }
+      "L’outil de calcul de votre index égalité professionnelle Femmes-Hommes",
+  },
 };
 
 <LayoutArticle meta={meta} startup="egapro">
+
+<!-- start content -->
 
 Le 9 janvier 2019, le Ministère du Travail publiait le décret obligeant les entreprises à calculer et à déclarer leur index de l'égalité professionnelle conçu pour faire progresser l’égalité salariale entre les femmes et les hommes au sein des entreprises.
 
@@ -22,5 +24,7 @@ Avec l'outil de simulation en ligne Egapro, les entreprises peuvent calculer leu
 ## Nos prochains développements
 
 Pour le moment, le calculateur est configuré pour les entreprises de plus de 250 salariés : il le sera bientôt pour les entreprises de 50 à 250 salariés !
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/egapro.mdx
+++ b/pages/startups/egapro.mdx
@@ -15,15 +15,13 @@ export const meta = {
 
 <!-- start content -->
 
-Le 9 janvier 2019, le Ministère du Travail publiait le décret obligeant les entreprises à calculer et à déclarer leur index de l'égalité professionnelle conçu pour faire progresser l’égalité salariale entre les femmes et les hommes au sein des entreprises.
+L’index d'égalité professionnelle a été conçu pour faire progresser au sein des entreprises l’égalité salariale entre les femmes et les hommes.
 
 Il permet aux entreprises de mesurer, en toute transparence, les écarts de rémunération entre les sexes et de mettre en évidence leurs points de progression. Lorsque des disparités salariales sont constatées, des mesures de correction doivent être prises.
 
-Avec l'outil de simulation en ligne Egapro, les entreprises peuvent calculer leur index de façon simple et rapide, tout en bénéficiant d’éclairages spécifiques sur les détails de calcul de chaque indicateur et sur les questions les plus fréquemment posées.
+Le produit Index Egapro permet aux entreprises de plus de 50 salariés de calculer et déclarer leur index égalité professionnelle.
 
-## Nos prochains développements
-
-Pour le moment, le calculateur est configuré pour les entreprises de plus de 250 salariés : il le sera bientôt pour les entreprises de 50 à 250 salariés !
+La page annexe https://index-egapro.travail.gouv.fr/consulter-index permet au grand public de consulter les index publics, à savoir ceux des entreprises de plus de 1000 salariés (ceux des entreprises de +250 salariés seront rendus publics à compter du 01/01/21)
 
 <!-- end content -->
 

--- a/pages/startups/fce.mdx
+++ b/pages/startups/fce.mdx
@@ -1,16 +1,20 @@
 import { BlocCards, LayoutArticle, StartupMembers } from "../../src/composants";
 
 export const meta = {
-title: "Faciliter l’accès aux informations disponibles sur les entreprises et les échanges entre services",
-hero: {
-background: "/images/startups/dayne-topkin-101954_FCE.jpg",
-alt: "Photo by Dayne Topkin",
-title: "Fiche commune entreprise",
-tagline: "Un portail pour faciliter l’accès aux informations disponibles sur les entreprises et les échanges entre services"
-}
+  title:
+    "Faciliter l’accès aux informations disponibles sur les entreprises et les échanges entre services",
+  hero: {
+    background: "/images/startups/dayne-topkin-101954_FCE.jpg",
+    alt: "Photo by Dayne Topkin",
+    title: "Fiche commune entreprise",
+    tagline:
+      "Un portail pour faciliter l’accès aux informations disponibles sur les entreprises et les échanges entre services",
+  },
 };
 
 <LayoutArticle meta={meta} startup="fce">
+
+<!-- start content -->
 
 Les agents des Direccte interviennent dans la vie des entreprises sur des champs variés (emploi, travail, développement économique, protection des consommateurs) et pour des motifs différents qui peuvent parfois être contradictoires.
 Par exemple, un agent peut intervenir auprès d’une entreprise pour s’assurer du respect de la durée légale du travail, alors qu’un autre vérifie l’application des règles liées à la concurrence et qu’un troisième lui octroie un financement pour favoriser le développement de l’emploi des seniors.
@@ -27,5 +31,7 @@ Grâce à FCE, les entreprises mieux connues à priori par les services, auront 
 
 **Un produit initié par une Direccte à co-construire avec les Direcctes**
 Un prototype simplifié de FCE a été initié par la Direccte Occitanie au début de l’année 2018. Afin de généraliser l’utilisation de l’outil à l’ensemble des Direcctes, il a été décidé de poursuivre son développement au sein de la fabrique numérique des ministères sociaux.
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/mano.mdx
+++ b/pages/startups/mano.mdx
@@ -1,16 +1,20 @@
 import { LayoutArticle, Timeline, TimelineEvent } from "../../src/composants";
 
 export const meta = {
-  title: "Service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion. ",
+  title:
+    "Service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion. ",
   hero: {
     background: "/images/startups/mano.jpg",
     alt: "Photo by Anaïd De Dieuleveult 2012",
     title: "MANO",
-    tagline: "Service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion. "
-  }
+    tagline:
+      "Service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion. ",
+  },
 };
 
 <LayoutArticle meta={meta} startup="mano">
+
+<!-- start content -->
 
 > MANO est un service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion.
 
@@ -37,5 +41,7 @@ Le service MANO manipulant des données de santé, une analyse d’impact (EIVP)
 Les prochaines étapes consistent à collecter un maximum de retours de la part des maraudeurs pour définir la prochaine salve d’améliorations à apporter au service
 
 Le service sera d’ailleurs prochainement disponible pour le suivi des personnes hébergées dans le cadre de mise à l'abri et présenté à d’autres maraudes de la région parisienne (Gaïa, Aurore) pour évaluer la possible adéquation avec leurs pratiques.
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/mano.mdx
+++ b/pages/startups/mano.mdx
@@ -16,31 +16,86 @@ export const meta = {
 
 <!-- start content -->
 
-> MANO est un service de soutien aux équipes mobiles visant à améliorer la vie des populations en rue et à favoriser leur réinsertion.
+# **Le problème**
 
-Le service permet notamment, par l’intermédiaire d’une application mobile, de :
+Les personnes vivant à la rue présentent de grandes problématiques sociales et médicales. Elles y souffrent de pathologies importantes, et elles y meurent. C’est le lot de 100 000 à 800 000 personnes en France (source : observatoire des inégalités).
 
-- Planifier des actions (soins, accompagnements, démarches, orientations) à réaliser en lien avec les besoins individuels des personnes rencontrées en rue
-- Collecter et de partager des informations relatives aux populations afin d’améliorer la qualité de l’accompagnement et des soins dispensés
-- Mener à bien les démarches administratives relatives aux populations
-- Orienter au mieux et au plus proche les populations en fonction de leurs besoins
+Les maraudes sont le dernier lien avec ces usagers pour les aider à vivre et à améliorer leur situation. Les maraudes vont à la rencontre des usagers dans la rue pour leur prodiguer des soins, les aider dans leurs démarches de droits communs, les orienter vers des structures d'accueil, des lieux ou trouver à manger et une maraude, c’est la perspective d’une éventuelle réinsertion.
 
-# Situation au 26/08/20
+Une Maraude c’est plusieurs heures en rue sans accès à un ordinateur. C’est plusieurs équipes qui se relaient toute la semaine et qui doivent échanger des informations, c’est plusieurs centaines d’usagers avec des problématiques individuelles complexes à accompagner dans la durée.
 
-Durant le mois d’août 2020, la première version de l’application a été développée et soumise avec succès aux équipes du CAARUD EGO.
+Et une maraude réussie, c’est quand on a rappelé ou accompagné Jean à son audience car il avait oublié qu’il risquait de perdre sa liberté. C’est quand on retrouve Irène pour refaire le pansement de sa plaie ouverte et pour reparler de sa procédure de logement, c’est quand à la fin on a transmis à ses collègues les dizaines d’actions à faire le lendemain ou dans 5 jours quand ils seront sur le terrain.
 
-Cette première version contient :
+Et le problème, c’est que les Maraude n’ont pas d’outil pour cela.
 
-- Un gestionnaire de tâches collaboratif
-- Un dossier usager recensant les actions effectuées et permettant une continuité du suivi grâce à l'accès en rue aux informations concernant l'usager.
-- Un annuaire des structures vers lesquelles orienter les usagers
-- Un formulaire d’évaluation de la qualité du service
+# **La solution**
 
-Le service MANO manipulant des données de santé, une analyse d’impact (EIVP) a été réalisée par les services compétents de la Fabrique Numérique du MAS et un hébergement HDS adéquat a été mis en oeuvre (dans le centre Microsoft Azure de Paris).
+MANO a été créé pour offrir aux Maraudes les moyens d’avoir un plus grand impact sur leur public, en les aidant à organiser leurs maraudes, en améliorant l’accompagnement des personnes rencontrées en rue, et en enrichissant la connaissance du territoire sur lequel ces maraudes interviennent.
 
-Les prochaines étapes consistent à collecter un maximum de retours de la part des maraudeurs pour définir la prochaine salve d’améliorations à apporter au service
+\
+L’application MANO  permet d’avoir accès à :
 
-Le service sera d’ailleurs prochainement disponible pour le suivi des personnes hébergées dans le cadre de mise à l'abri et présenté à d’autres maraudes de la région parisienne (Gaïa, Aurore) pour évaluer la possible adéquation avec leurs pratiques.
+\- Un “dossier usager” permettant de connaître la situation sociale et médicale de la\
+personne, et ainsi d’aller vers une prise en charge globale et sans perte d’information
+
+\- Un planificateur de tâches relié aux “dossiers usager” qui permet d’avoir une\
+visibilité sur les actions du jour et à venir, afin de pouvoir prioriser les actions, ne pas oublier d’action à réaliser, et de gagner en efficacité
+
+\- Un accès à une liste de structures spécifiques sur lesquelles orienter la personne en rue le plus simplement possible
+
+ 
+
+L’interface Web permet à chaque maraude :
+
+\- de Paramétrer “son MANO” pour l’adapter au mieux à son activité propre
+
+\- de créer des compte rendu de fin de maraude
+
+\- de consolider automatiquement des indicateurs pour les financeurs
+
+ 
+
+# **La mesure d’impact et les objectifs**
+
+ Les deux indicateurs retenus pour mesurer l’impact du services sont :
+
+\- Le taux de maraudeur utilisant MANO quotidiennement au sein des maraudes équipées. Nous partons de l’hypothèse que si l’outil est utilisé au quotidien, c’est qu’il répond à un besoin réel.
+
+\- Le nombre d’usager suivi via MANO
+
+Nous estimons que cette première phase d’expérimentation sera un succès si au bout des 6 premiers mois si nous avons :
+
+\- Un taux d’utilisation au quotidien de l’outil par 90% des maraudeurs équipées
+
+\- 500 usagers suivi via l’application
+
+# **La démarche pour y arriver et point d’étape**
+
+MANO naît de la volonté du CAARUD EGO Aurore et de sa maraude, d’avoir plus d’impact auprès des usagers de drogues en grande précarité. C’est pourquoi MANO fait ses premiers pas dans la maraude d’EGO.
+
+La stratégie de cette première phase est par la suite de déployer MANO dans 3 autres structures pour valider le besoin, identifier des corrections pour le MVP et commencer à l’enrichir. Dès que la validation du besoin est réalisée, MANO sera déployé plus largement.
+
+Le service MANO manipulant des données de santé, une analyse d’impact (EIVP) a été réalisée par les services compétents de la Fabrique du Numérique du ministère des solidarités et de la santé et un hébergement HDS adéquat a été mis en oeuvre (dans le centre Microsoft Azure de Paris).
+
+
+
+## Principaux évènements :
+
+\- 1er Août : lancement de la SE
+
+\- Fin aout : première version de l’application
+
+\- Début septembre : premier test de l’outil au sein de EGO-
+
+\- Fin septembre : Déploiement sur la maraude de la coordination toxicomanie
+
+\- Au 3 novembre : 100 usagers suivis
+
+\- Mi-novembre : Déploiement sur les maraudes Aurore Est et Ouest
+
+\- A 1er Décembre : 284 usagers suivis
+
+\- Fin décembre : première version de l’interface web
 
 <!-- end content -->
 

--- a/pages/startups/medle.mdx
+++ b/pages/startups/medle.mdx
@@ -7,32 +7,33 @@ export const meta = {
     background: "/images/startups/medle.jpg",
     title: "MedLé",
     tagline:
-      "Permettre aux structures de médecine légale de consigner l'activité réalisée sur réquisition judiciaire et les personnels affectés."
-  }
+      "Permettre aux structures de médecine légale de consigner l'activité réalisée sur réquisition judiciaire et les personnels affectés.",
+  },
 };
 
 <LayoutArticle meta={meta} startup="medle">
 
-# MedLé
+<!-- start content -->
 
-« Permettre aux structures de médecine légale de consigner l'activité réalisée
-sur réquisition judiciaire et les personnels affectés ».
+# Medlé
 
-## LE PRODUIT
+« Permettre aux structures de médecine légale de consigner l'activité réalisée sur réquisition judiciaire et les personnels affectés ».
 
-Medlé a pour objectif de faciliter la déclaration, la consultation et l'évaluation d'une part, de toutes les activités médico-légales réalisées dans les structures hospitalières dédiées, d'autre part des professionnels dédiés.
+## Le produit
+
+Medlé a pour objectif de faciliter la déclaration, la consultation et l'évaluation d'une part, de toutes les activités médico-légales réalisées dans les structures hospitalières dédiées, d'autre part, des professionnels dédiés.
 
 Pour les ministères, Medlé permet une vision plus exhaustive des actes réalisés.
 
-- **SECTEUR** : santé, justice et intérieur
-- **PUBLIC CONCERNE** : UMJ (Unités Médico-Judiciaires), IML (Instituts MédicoLégaux) et réseaux de proximité
+- **secteur** : santé, justice et intérieur
+- **public concerné** : UMJ (Unités Médico-Judiciaires), IML (Instituts MédicoLégaux) et réseaux de proximité
 
-## QUELQUES CHIFFRES CLES
+## Quelques chiffres clés
 
 - 47 UMJ dont 31 avec un IML
 - 290 604 actes déclarés en 2018 (Hôtel Dieu compris).
 
-## LʼEQUIPE
+## L'équipe
 
 - Eric Heijligers – Coach
 - Marie-Odile Moreau – Product Owner
@@ -40,7 +41,7 @@ Pour les ministères, Medlé permet une vision plus exhaustive des actes réalis
 - Christophe Grassi - Product Manager
 - Pierre-Olivier Mauguet - Développeur
 
-## 01 LE CONTEXTE
+## 1 - Le contexte
 
 ### Qu'est-ce que la médecine légale ?
 
@@ -48,7 +49,9 @@ La médecine légale nʼexiste que dans le cadre dʼune procédure pénale. Elle
 
 Une grande partie de cette activité est aujourdʼhui réalisée dans les **47 structures hospitalières**. Un réseau de proximité (établissements publics de santé dépourvus de structures dédiées et médecine libérale) complète le maillage territorial.
 
-Les structures de médecine légale thanatologique sont désormais appelées institut médico-légal (IML) ; celles de médecine légale du vivant sont appelées unité médico-judiciaire (UMJ). Un outil informatique existant obsolète
+Les structures de médecine légale thanatologique sont désormais appelées institut médico-légal (IML) ; celles de médecine légale du vivant sont appelées unité médico-judiciaire (UMJ). 
+
+### Un outil informatique existant obsolète
 
 Dans le cadre de la réforme et dès 2011, en lʼabsence dʼoutils informatiques, le Ministère de la Santé a mis en place une plateforme de renseignements : lʼobservatoire National de la Médecine Légale (oNML). La totalité des examens de médecine légale qui sont réalisés, sont consignés par les établissements de santé sièges dʼune structure à lʼexception de lʼunité médico-judiciaire de lʼHôtel-Dieu à Paris, des IML de lʼIRCGN (Institut de Recherche Criminologique de la Gendarmerie Nationale) et de la Préfecture de Police de Paris placés tous les deux sous lʼautorité du ministère de lʼintérieur. Il en est de même des effectifs alloués au regard de lʼorganisation prévue par le schéma.
 
@@ -58,49 +61,51 @@ Cette plateforme ne prend pas en compte lʼactivité réalisée par le réseau d
 
 LʼoNML a peu évolué en fonction des usages et des besoins de ses utilisateurs actuels, d'un point de vue métier mais également d'un point de vue expérience utilisateur.
 
-**BILAN** : en plus de représenter une activité fastidieuse et chronophage pour le personnel des UMJ et IML et dʼêtre vécue comme un seul outil de contrôle, elle ne permet aujourd'hui pas aux ministères de la Santé, de la Justice et de l'Intérieur de dresser un bilan précis et exhaustif de lʼactivité réalisée sur lʼensemble du territoire national.
+**Bilan** : en plus de représenter une activité fastidieuse et chronophage pour le personnel des UMJ et IML et dʼêtre vécue comme un seul outil de contrôle, elle ne permet aujourd'hui pas aux ministères de la Santé, de la Justice et de l'Intérieur de dresser un bilan précis et exhaustif de lʼactivité réalisée sur lʼensemble du territoire national.
 
 Comment concevoir un outil de reporting de l'activité médico-légale qui permettent aux ministères d'avoir un suivi exhaustif de l'activité, tout en ayant une valeur ajoutée pour les utilisateurs finaux (UMJ et IML) ?
 
-## 02 LE PRODUIT
+## 2 - Le produit
 
 ### Notre engagement
 
-Compte tenu de la nécessité absolue dʼun outil fiable et sécurisé de recueil, de gestion et dʼanalyse de données médico-légales pour les ministères de la Santé de la Justice et de lʼIntérieur, la startup Medlé a été créée mi-juin 2019 au sein de la fabrique numérique des ministères sociaux. Elle est donc placée sous le contrôle de l'Etat pour des raisons de confidentialité et de coût.
+Compte tenu de la nécessité absolue dʼun outil fiable et sécurisé de recueil, de gestion et dʼanalyse de données médico-légales pour les ministères de la Santé de la Justice et de lʼIntérieur, la startup Medlé a été créée mi-juin 2019 au sein de lʼincubateur des ministères sociaux. Elle est donc placée sous le contrôle de l'Etat pour des raisons de confidentialité et de coût.
 
 MedLé permet d'évaluer facilement lʼactivité de médecine légale réalisée sur réquisition judiciaire, dans un premier temps au niveau des 47 structures hospitalières (LʼHôtel-Dieu de Paris inclus), puis dans un second temps au niveau du réseau de proximité et des IML de lʼIRCGN et de la Préfecture de Police de Paris.
 
 Pour le ministère de la Santé, mais également le cas échéant pour les ministères de la Justice et de lʼIntérieur, le produit permettra dʼêtre la pierre angulaire à dʼautres projets, dont lʼun est déjà identifié par la DGOS.
 
-### Nos utilisateurs cibles :
+### Nos utilisateurs cibles
 
 Cette plateforme sera utilisée par :
 
-- Le personnel des UMJ et des IML, afin de leur donner une vue représentative et utile au quotidien de l'activité médico-légale, au sein de leur établissement mais également au niveau national ;
-- Le personnel administratif des établissements de santé, l'outil leur permettant d'extraire facilement les données nécessaires à la rédaction des mémoires de frais et fluidifiant les relations avec les TGI et la Chancellerie ;
-- Les ministères, leur permettant de disposer d'indicateurs afin de mieux ajuster l'offre aux besoins.
-- A terme lʼensemble des utilisateurs y compris ceux du réseau de proximité
+- le personnel des UMJ et des IML, afin de leur donner une vue représentative et utile au quotidien de l'activité médico-légale, au sein de leur établissement mais également au niveau national
+- le personnel administratif des établissements de santé, l'outil leur permettant d'extraire facilement les données nécessaires à la rédaction des mémoires de frais et fluidifiant les relations avec les TGI et la Chancellerie
+- les ministères, leur permettant de disposer d'indicateurs afin de mieux ajuster l'offre aux besoins.
+- à terme, lʼensemble des utilisateurs y compris ceux du réseau de proximité
 
-## 03 LES DATES CLES
+## 3 - Les dates clées
 
-### Juillet-Août 2019 : Phase de recherche utilisateurs
+### Juillet-août 2019 : phase de recherche utilisateurs
 
-Une première phase dʼentretiens avec, d'une part des responsables administratifs, dʼétablissement de santé, des médecins légistes, des secrétaires au sein des UMJ/IML, une ARS, d'autre part avec les ministères de la justice, de lʼintérieur, des officiers de police judiciaire (OPJ) dans des commissariats, nous ont permis de comprendre les difficultés rencontrées, les besoins dʼamélioration et les véritables usages sur le terrain.
+Une première phase dʼentretiens avec, d'une part des responsables administratifs, dʼétablissement de santé, des médecins légistes, des secrétaires au sein des UMJ/IML, une ARS, et d'autre part avec les ministères de la justice, de lʼintérieur, des officiers de police judiciaire (OPJ) dans des commissariats, nous ont permis de comprendre les difficultés rencontrées, les besoins dʼamélioration et les véritables usages sur le terrain.
 
-### Septembre 2019 : Scénarios et maquettes
+### Septembre 2019 : scénarios et maquettes
 
 La construction des scénarios et parcours utilisateur et la création des maquettes adaptées nous permettront de tester rapidement notre produit et de commencer le développement.
 
-### Octobre-Décembre 2019 : Tests utilisateurs et développement
+### Octobre-décembre 2019 : tests utilisateurs et développement
 
 Les briques de base étant déjà déterminées, le développement du MVP sera réalisé en même temps que les tests utilisateurs, permettant ainsi des améliorations rapides du produit.
 
-### Décembre 2019 : Sortie du MVP
+### Décembre 2019 : sortie du MVP
 
 Ce premier MVP remplacera l'outil existant, permettant une continuité de la consignation d'activité pour les UMJ et IML pilotes. Il permettra de déclarer les actes réalisés dans la structure ainsi les ETP nécessaires à cette activité.
 
 ### Juin 2020 : Déploiement au niveau des 47 structures hospitalières y compris lʼUMJ majeurs et mineurs de lʼHôtel-Dieu.
 
 A terme, déploiement à lʼensemble du réseau de proximité et aux IML de lʼIRCGN et de Paris avec lʼaccord du ministère de lʼintérieur.
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/monsuivipsy.mdx
+++ b/pages/startups/monsuivipsy.mdx
@@ -14,6 +14,7 @@ export const meta = {
 
 <LayoutArticle meta={meta} startup="monsuivipsy">
 
+<!-- start content -->
 
 ## Mon Suivi Psy, c'est mieux connaître mes symptômes pour un meilleur accompagnement par mon médecin
 
@@ -53,5 +54,6 @@ Mon Suivi Psy, c'est une aide pour un dialogue continu, qui s'adresse à tous, c
 
 Mon Suivi Psy, c'est permettre aux personnes suivies de rester au plus près de leur expérience et d'en rendre compte le plus fidèlement possible au médecin, pour lui permettre de participer à soulager la souffrance grâce à une intervention médicamenteuse adéquate, personnalisée et rapide.
 
-</LayoutArticle>
+<!-- end content -->
 
+</LayoutArticle>

--- a/pages/startups/monsuivipsy.mdx
+++ b/pages/startups/monsuivipsy.mdx
@@ -16,43 +16,46 @@ export const meta = {
 
 <!-- start content -->
 
-## Mon Suivi Psy, c'est mieux connaître mes symptômes pour un meilleur accompagnement par mon médecin
+Les troubles psychiatriques touchent plus de 20 % de la population, à un moment de la vie. Et trouver le bon traitement peut prendre plusieurs années. Pendant ce temps-là, les symptômes évoluent, peuvent devenir chroniques et l’état du patient s’aggrave. L’impact peut être dramatique. 
 
-Les troubles psychiatriques touchent plus de 20 % de la population, à un moment de la vie.
+**Comment en arrive-t-on là ?**
 
-Et trouver le bon traitement peut prendre plusieurs années. Pendant ce temps-là, les symptômes évoluent, peuvent devenir chroniques et l'état du patient s'aggrave. L'impact peut être dramatique.
+Le médecin choisit ou modifie un traitement en se basant sur ce que lui rapporte la personne  durant la consultation. Mais le médecin n’a que peu de temps avec la personne concernée et les informations rapportées ne sont pas fiables. 
 
-## Comment en arrive-t-on là ?
+Les jeunes que nous avons interrogés rapportent en effet avoir du mal à dire tout ce qu’ils souhaitent en consultation et expliquent repartir en ayant bien souvent omis de transmettre une ou plusieurs informations importantes. 
 
-Le médecin choisit ou modifie un traitement en se basant sur ce que lui rapporte la personne durant la consultation. Mais le médecin n'a que peu de temps avec la personne concernée et
-les informations rapportées ne sont pas fiables.
+C’est qu’il est très difficile de donner une représentation fiable de ses symptômes et de l’évolution de ceux-ci. 
 
-Les jeunes que nous avons interrogés rapportent en effet avoir du mal à dire tout ce qu'ils souhaitent en consultation et expliquent repartir en ayant bien souvent omis de transmettre une ou plusieurs informations importantes.
+**Pourquoi ?** Car aucun humain n’est capable de se souvenir fidèlement de l’évolution de son état psychique sur une durée trop longue. 
 
-## C'est qu'il est très difficile de donner une représentation fiable de ses symptômes et de l'évolution de ceux-ci.
+Il est par exemple quasiment impossible de se rappeler la qualité de son sommeil 3 semaines auparavant, d’être suffisamment précis sur le nombre de crise d’angoisse survenues le mois dernier, l’intensité de celles-ci et leur impact sur notre quotidien, ou encore de se rappeler de ces jours où ça allait vraiment bien, alors que les jours précédant le rendez-vous, la tristesse nous a envahit…
 
-Pourquoi ? Car aucun humain n'est capable de se souvenir fidèlement de l'évolution de son état psychique sur une durée trop longue.
+**Mon Suivi Psy est fait pour ça !**
 
-Il est par exemple quasiment impossible de se rappeler la qualité de son sommeil 3 semaines auparavant, d'être suffisamment précis sur le nombre de crise d'angoisse survenues le mois dernier, l'intensité de celles-ci et leur impact sur notre quotidien, ou encore de se rappeler de ces jours où ça allait vraiment bien, alors que les jours précédant le rendez-vous, la tristesse nous a envahit…
+Plus les informations concernant mes symptômes sont proches de la réalité, de ce que je vis, plus mon médecin sera en mesure de me prescrire le bon traitement, celui qui sera le plus efficace possible avec le moins d’effets indésirables.
 
-## Mon Suivi Psy est fait pour ça
+Mon Suivi Psy, c’est une aide pour un dialogue continu, qui s’adresse à tous, co-construite avec les usagers, comprenant :
 
-Plus les informations concernant mes symptômes sont proches de la réalité, de ce que je vis, plus mon médecin sera en mesure de me prescrire le bon traitement, celui qui sera le plus efficace possible avec le moins d'effets indésirables.
+* La possibilité de sélectionner les symptômes et les effets indésirables des traitements médicamenteux à suivre 
+* Un rappel quotidien pour m’aider à y penser
+* Des écrans simples permettant une saisie rapide
+* Une synthèse de l’évolution de l’intensité des symptômes au cours du temps
+* Un accès à des données informatives concernant les symptômes suivis
+* Un parcours motivationnel dans la participation à son suivi
 
-Mon Suivi Psy, c'est une aide pour un dialogue continu, qui s'adresse à tous, co-construite avec les usagers, comprenant :
+Mon Suivi Psy, c’est permettre aux personnes suivies de rester au plus près de leur expérience et d’en rendre compte le plus fidèlement possible au médecin, pour lui permettre de participer à soulager la souffrance grâce à une intervention médicamenteuse adéquate, personnalisée et rapide.
 
-- La possibilité de sélectionner les symptômes et les effets indésirables des traitements médicamenteux à suivre
-- Un rappel quotidien pour m'aider à y penser
-- Des écrans simples permettant une saisie rapide
-- Une synthèse de l'évolution de l'intensité des symptômes au cours du temps
-- Un accès à des données informatives concernant les symptômes suivis
-- Un parcours motivationnel dans la participation à son suivi
+**Mesure d’impact et objectifs**
 
-<br />
-<br />
-<br />
+Les deux indicateurs permettant de mesurer l’impact du services sont : 
 
-Mon Suivi Psy, c'est permettre aux personnes suivies de rester au plus près de leur expérience et d'en rendre compte le plus fidèlement possible au médecin, pour lui permettre de participer à soulager la souffrance grâce à une intervention médicamenteuse adéquate, personnalisée et rapide.
+* Le nombre d’utilisateurs engagés, c’est-à-dire le nombre d’utilisateurs saisissant des données sur au moins 2 semaines glissantes avec 3 saisies ou plus par semaine
+* Le nombre de praticiens engagés, c’est-à-dire le nombre de praticiens déclarant que le service les a aidés dans l’orientation de la prise en charge de la personne suivie et, que cela soit d’un point du vue diagnostic, thérapeutique ou de soins plus globalement. 
+
+Nous estimons que cette première phase d’expérimentation sera un succès si au bout des 6 premiers mois nous avons : 
+
+* 200 utilisateurs engagés et
+* 50 praticiens engagés
 
 <!-- end content -->
 

--- a/pages/startups/ozensemble.mdx
+++ b/pages/startups/ozensemble.mdx
@@ -12,17 +12,17 @@ export const meta = {
 
 <LayoutArticle meta={meta} startup="ozensemble">
 
+<!-- start content -->
 
-## Le défaut d'accès aux soins condamne les personnes souffrant de conduites addictives
+##   Le défaut d'accès aux soins condamne les personnes souffrant de conduites addictives
 
-Aujourd’hui en France, 5 millions de personnes souffrent d’une dépendance à l’alcool qui reste la deuxième cause de mortalité prématurée évitable après le tabac.
+Aujourd’hui en France, 5 millions de personnes souffrent d’une dépendance à l’alcool qui reste la deuxième cause de mortalité prématurée évitable après le tabac.  
 
 Selon le rapport 2018 de la MILDECA, seuls 5 % des personnes dépendantes à l’alcool font
-l’objet d’un suivi régulier. Ainsi sur le seul département de la Seine-Saint-Denis, 180 000
+l’objet d’un suivi régulier. Ainsi sur le seul département de la Seine-Saint-Denis, 180 000
 personnes échapperaient aux soins.
 
 Après enquête auprès de personnes présentant un trouble identifié par des structures de soins partenaires (médecin de ville, CMS) mais non suivies, les principaux problèmes auxquels ces personnes font face sont :
-
 - Je n’arrive pas à m’approprier mon trouble
 - Je ne suis pas acteur de mon parcours
 - Personne n’est pas là pour moi au moment où j’en ressent le plus le besoin
@@ -31,7 +31,6 @@ Après enquête auprès de personnes présentant un trouble identifié par des s
 
 Oz Ensemble est une plateforme d’addictologie dématérialisée s’adressant à tous.
 La plateforme s’appuie d’une part sur une application mobile, co-construite avec les usagers, alliant pour la première fois :
-
 - Un module de repérage précoce sous la forme d’un bilan et d’un agenda de consommation numériques et interactifs.
 - Un point d’accès à un professionnel du soins sous 48h.
 - Un parcours motivationnel valorisant le patient dans la réduction de sa consommation
@@ -42,5 +41,6 @@ Ainsi, nous souhaitons favoriser le passage vers une démarche de soin en s'appu
 Cet outil s'intégre dans l'arsenal des orienteurs et est particulièrement plébiscité par ceux-ci. En effet, pour d'autres pathologies, la mise à disposition d'un outil d'automesure a démontré l'efficacité sur la prise de conscience des troubles par les patients.
 La combinaison avec l'orientation vers des structures adaptées permettra une identification facile des centres par le patient le jour où il sera prêt.
 
-</LayoutArticle>
+<!-- end content -->
 
+</LayoutArticle>

--- a/pages/startups/textstyle.mdx
+++ b/pages/startups/textstyle.mdx
@@ -1,16 +1,18 @@
 import { BlocCards, LayoutArticle, StartupMembers } from "../../src/composants";
 
 export const meta = {
-title: "TextStyle simplifie la rédaction des textes normatifs",
-hero: {
-background: "/images/startups/patrick-tomasso-Oaqk7qqNh_c-unsplash.jpg",
-alt: "Photo by Patrick Tomasso",
-title: "TextStyle",
-tagline: "TextStyle simplifie la rédaction des textes normatifs"
-}
+  title: "TextStyle simplifie la rédaction des textes normatifs",
+  hero: {
+    background: "/images/startups/patrick-tomasso-Oaqk7qqNh_c-unsplash.jpg",
+    alt: "Photo by Patrick Tomasso",
+    title: "TextStyle",
+    tagline: "TextStyle simplifie la rédaction des textes normatifs",
+  },
 };
 
 <LayoutArticle meta={meta} startup="textstyle">
+
+<!-- start content -->
 
 **LE PRODUIT**
 
@@ -95,5 +97,7 @@ Premier MVP à faire tester.
 **06 ARTICLES SUR TEXTSTYLE **
 
 Nous contacter: textstyle@fabrique.social.gouv.fr
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/tremplin.mdx
+++ b/pages/startups/tremplin.mdx
@@ -1,52 +1,57 @@
 import { BlocCards, LayoutArticle, StartupMembers } from "../../src/composants";
 
 export const meta = {
-title: "Rapprocher les professionnels de santé de leur futur territoire d’exercice",
-hero: {
-background: "/images/startups/rawpixel-602153-unsplash.jpg",
-alt: "Photo by Rawpixel",
-title: "Tremplin : Territoire REMPLacement INstallation",
-tagline: "Rapprocher les professionnels de santé de leur futur territoire d’exercice"
-}
+  title:
+    "Rapprocher les professionnels de santé de leur futur territoire d’exercice",
+  hero: {
+    background: "/images/startups/rawpixel-602153-unsplash.jpg",
+    alt: "Photo by Rawpixel",
+    title: "Tremplin : Territoire REMPLacement INstallation",
+    tagline:
+      "Rapprocher les professionnels de santé de leur futur territoire d’exercice",
+  },
 };
 
 <LayoutArticle meta={meta} startup="tremplin">
 
-** Comment une diffusion de l’information inadaptée renforce les déserts médicaux. **
+<!-- start content -->
+
+## TREMPLIN : Territoire REMPLacement INstallation
+*Rapprocher les professionnels de santé de leur futur territoire d’exercice*
+
+## Comment une diffusion de l’information inadaptée renforce les déserts médicaux
 
 Aujourd’hui, plus de 5 millions de français vivent dans une zone déficitaire en médecin.
 
-Et si certains déserts médicaux résultaient d’un mauvais partage d’informations plutôt que d'un problème d’attractivité ?
+Et si certains déserts médicaux résultaient d’un mauvais partage d’informations plutôt que d’un problème d'attractivité?
 
-- D’un côté, les professionnels de santé cherchent leurs futurs lieux d’installation en fonction de critères professionnels (infrastructures médicales, patientèle, aides publiques à l'installation...) et personnels (emploi du conjoint, écoles, transports, offres de loisirs etc…). Pour trouver les bonnes informations, ils doivent consulter de nombreuses sources peu accessibles ou de qualité variable. Ainsi, un professionnel de santé, même s’il aspire à une installation dans une commune rurale, peut s’installer, par défaut, à proximité d’un centre urbain qui garantit une réponse à ses contraintes personnelles.
-
-- De l’autre côté, les acteurs des territoires (soignants, collectivités,…) qui cherchent à attirer de nouveaux professionnels, le temps d’un remplacement ou pour une installation rencontrent des difficultés pour mettre en valeur et diffuser leurs offres.
+* D’un côté, les professionnels de santé cherchent leurs futurs lieux d’installation en fonction de critères professionnels (infrastructures médicales, patientèle, aides publiques à l'installation...) et personnels (emploi du conjoint, écoles, transports, offres de loisirs etc…). Pour trouver les bonnes informations, ils doivent consulter de nombreuses sources peu accessibles ou de qualité variable. Ainsi, un professionnel de santé, même s’il aspire à une installation dans une commune rurale, peut s’installer, par défaut, à proximité d’un centre urbain qui garantit une réponse à ses contraintes personnelles.
+* De l’autre côté, les acteurs des territoires (soignants, collectivités,…) qui cherchent à attirer de nouveaux professionnels, le temps d’un remplacement ou pour une installation rencontrent des difficultés pour mettre en valeur et diffuser leurs offres.
 
 Certaines opportunités au sein de déserts médicaux ne trouvent donc pas preneur alors même qu’elles correspondent à ce que recherchent les soignants.
 
-**Pourquoi Tremplin ?**
+## Pourquoi Tremplin ?
 
 De nombreux dispositifs d'accompagnement existent, et pourtant les professionnels de santé doivent consacrer beaucoup trop de temps et d’énergie à leur recherche.
 
-Les acteurs des territoires (soignants, collectivités,…) s’investissent beaucoup pour attirer de nouveaux soignants et pourtant ils peinent à être visibles.
+Les acteurs des territoires (soignants, collectivités,…)  s’investissent beaucoup pour attirer de nouveaux soignants et pourtant ils peinent à être visibles.
 
 Tremplin se donne pour objectifs de:
 
-- permettre aux professionnels de santé d'accéder à une information plus complète, plus facilement, en indiquant, pour chaque territoire:
+* permettre aux professionnels de santé d'accéder à une information plus complète, plus facilement,  en indiquant, pour chaque territoire:
+  * le cadre de vie
+  * les opportunités
+  * les contacts des acteurs de terrain
 
-  - le cadre de vie
-  - les opportunités
-  - les contacts des acteurs de terrain
+* Renforcer l’action des acteurs de terrain et simplifier leurs démarches:
+  * en leur permettant de rédiger facilement et rapidement des annonces efficaces aux yeux des professionnels de santé.
+  * en publiant systématiquement chaque annonce sur plusieurs plateformes de diffusion.
 
-- Renforcer l’action des acteurs de terrain et simplifier leurs démarches:
-  - en leur permettant de rédiger facilement et rapidement des annonces efficaces aux yeux des professionnels de santé.
-  - en publiant systématiquement chaque annonce sur plusieurs plateformes de diffusion.
+En rendant visible les opportunités et les atouts existants sur les territoires, en permettant un vrai choix pour les professionnels de santé et en simplifiant la mise en relation,  Tremplin veut résorber une partie du problème des déserts médicaux et installer des soignants dans les territoires qui en ont le plus besoin.
 
-En rendant visible les opportunités et les atouts existants sur les territoires, en permettant un vrai choix pour les professionnels de santé et en simplifiant la mise en relation, Tremplin veut résorber une partie du problème des déserts médicaux et installer des soignants dans les territoires qui en ont le plus besoin.
+## Stratégie de développement
 
-**Stratégie de développement**
-
-- Par quoi commence-t-on ? Valoriser l’offre des territoires
+*Valoriser l’offre des territoires*
 
 Parce qu’un territoire se compose des personnes qui l’animent, il est nécessaire de permettre à tout acteur de terrain (soignants, institutions, …) de pouvoir relayer rapidement et efficacement ses besoins et ses projets, qu’il s’agisse d’offres de remplacement ou de propositions d’installation.
 
@@ -54,18 +59,24 @@ Nous commencerons par définir ce qu’est une annonce pertinente et efficace, a
 
 En parallèle, afin d’améliorer la visibilité de ces offres, nous établirons des partenariats avec des plateformes de diffusion qui partagent notre envie d’agir pour les territoires et qui se mettent aux services des professionnels. L’objectif est ici qu’avec une seule saisie, les offres des professionnels de terrain aient une visibilité accrues en étant relayées gratuitement et rapidement sur plusieurs canaux déjà existants.
 
-Notre premier indicateur de réussite sera notre capacité à générer ou à augmenter le nombre de candidatures sur les offres des acteurs de terrain accompagnés par Tremplin.
+Notre premier indicateur de réussite sera notre capacité à générer ou à augmenter le nombre de candidatures sur les offres des acteurs de terrain accompagnés  par Tremplin.
 
-- Comment on s’y prend ?
+*Comment on s’y prend?*
 
 Tremplin sera d’abord expérimenté sur le territoire de l’Occitanie avec pour objectif d’accompagner la médecine générale.
 
-Pour ce faire, nous sommes en lien avec des internes en médecine générale, des médecins généralistes remplaçants et installés , des plateformes de diffusion d’offres et leurs sponsors ainsi que des collectivités territoriales.
+Pour ce faire, nous sommes en lien avec des internes en médecine générale, des médecins généralistes remplaçants et installés , des plateformes de diffusion d’offres et leurs sponsors  ainsi que des collectivités territoriales.
 
-- Et ensuite? Rassembler les informations et accompagner les professionnels de santé dans leur prise de décision
+* Et ensuite? Rassembler les informations et accompagner les professionnels de santé dans leur prise de décision*
 
 Parce qu’il vaut mieux passer du temps à construire son projet qu’à compiler des données, il apparaît essentiel que les professionnels en recherche puissent consulter l’ensemble des informations et se mettre en lien avec le terrain rapidement et facilement.
 
 Tremplin proposera un outil de recherche permettant de mettre en avant les territoires qui correspondent le mieux aux critères de chaque professionnel de santé en recherche.
+
+## Arrêt de Tremplin
+
+Ce service a cessé son activité au 01/01/2020. Le produit n'a pas trouvé son public. L'offre portée par Tremplin n'a pas été jugée assez différenciante pour résoudre le problème des déserts médicaux.
+
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/tumeplay.mdx
+++ b/pages/startups/tumeplay.mdx
@@ -8,11 +8,13 @@ export const meta = {
     alt: "Photo by Harli Marten",
     title: "TuMePlay",
     tagline:
-      "L'app de la santé et de l'éducation sexuelle pour les moins de 25 ans"
-  }
+      "L'app de la santé et de l'éducation sexuelle pour les moins de 25 ans",
+  },
 };
 
 <LayoutArticle meta={meta} startup="tumeplay">
+
+<!-- start content -->
 
 # Nos constats
 
@@ -73,6 +75,8 @@ Plusieurs modes de distribution sont envisagés pour les “box” :
 - le point relais
 - la livraison chez un partenaire (mission locale, association locale, etc.)
 
+Notre [compte Instagram](https://www.instagram.com/tumeplay/).
+
 # Notre écosystème
 
 Trois ARS partenaires qui représentent nos territoires d'expérimentation : Guyane, Ile-de-France, Nouvelle-Aquitaine.
@@ -88,18 +92,6 @@ Des partenaires de distribution, qui constituent nos relais physiques après la 
 
 Il est très difficile de mesurer avec exactitude le taux d’IST sur un territoire donné c’est pourquoi nous comptons évaluer l’évolution des connaissances du jeune.
 
-# Notre équipe
-
-- Philippe Murat - Intrapreneur/Expert métier
-- Thierry Troussier - Intrapreneur/Expert métier
-- Thomas Menant - Coach
-- Aurélie Rolland - Designer UX
-- Yowa Muzadi - Business developer
-- Romain Petiteville - Développeur
-- Perrine Garnault - Designer UI/DA
-
-# Contact
-
-Pour nous contacter, écrire à [yowa.muzadi@fabrique.social.gouv.fr](mailto:yowa.muzadi@fabrique.social.gouv.fr) ou à [philippe.murat@sante.gouv.fr](mailto:philippe.murat@sante.gouv.fr)
+<!-- end content -->
 
 </LayoutArticle>

--- a/pages/startups/work-in-france.mdx
+++ b/pages/startups/work-in-france.mdx
@@ -6,31 +6,39 @@ export const meta = {
     background: "/images/startups/bruno-abatti-120376-unsplash.jpg",
     alt: "Photo by Bruno Abatti",
     title: "Work in France",
-    tagline: "La plateforme de demande d'autorisations provisoires de travail"
-  }
+    tagline: "La plateforme de demande d'autorisations provisoires de travail",
+  },
 };
 
 <LayoutArticle meta={meta} startup="work-in-france">
 
-Les étudiant·e·s étranger·e·s qui voudraient travailler en France, au-delà du mi-temps, doivent déposer une demande d'autorisation de travail en DIRECCTE. C'est généralement une démarche critique pour le projet de l'étudiant·e ; « pourrais-je rester en France, payer mes études, valider l'expérience professionnelle nécessaire à mon diplôme ? »
+<!-- start content -->
 
-### La demande d'autorisation de travail, ce parcours du combatant
+Les étudiantes étrangères et les étudiants étrangers qui voudraient travailler en France, au-delà du mi-temps, doivent déposer une demande d'autorisation de travail en DIRECCTE<sup>1</sup>. C'est généralement une démarche critique pour le projet étudiant ; « pourrais-je rester en France, payer mes études, valider l'expérience professionnelle nécessaire à mon diplôme ? »
 
-La demande d'autorisation de travail et la réception de l'autorisation se font aujourd'hui par courrier. Sans que l'étudiant·e et son employeur soient tenu·e·s informé·e·s de l'avancement de la demande.
+**La demande d’autorisation de travail, ce parcours du combattant**
+
+La demande d’autorisation de travail et la réception de l’autorisation se font aujourd’hui par courrier, sans renseignement en direct sur l'avancement de la demande.
 
 Légitimement, les usagers à la recherche de réponses concrètes contactent la DIRECCTE, voire se déplacent, pour être tenus informés du statut de leur demande :
 
-Avez-vous reçu ma demande ? Quand vais-je recevoir mon autorisation de travail ?
+> Avez-vous reçu ma demande ?
+> Quand vais-je recevoir mon autorisation de travail ?
 
-La **lenteur de la procédure** et son **manque de transparence** retardent ainsi la prise de poste et pénalisent l'entreprise qui n'est pas en mesure d'avoir une visibilité sur la validation du recrutement de son personnel.
+La lenteur de la procédure et son manque de transparence retardent ainsi la prise de poste et pénalisent l’entreprise qui n’est pas en mesure d’avoir une visibilité sur la validation du recrutement de son personnel.
 
-Les étudiant·e·s constituent la majeure partie du public qui se déplace à l'accueil des DIRECCTE. Que ce soit par téléphone, par mail ou dans les accueils, les agents passent un temps considérable à répondre aux questions des usagers, au détriment du traitement normal des demandes d'autorisation de travail. **Avec WorkInFrance, en traitant simplement la plupart des demandes, nous libérerons du temps de travail pour les agents.**
+Les étudiantes et les étudiants constituent la majeure partie du public qui se déplace à l'accueil des DIRECCTE. Que ce soit par téléphone, par mail ou dans les accueils, les agents passent un temps considérable à répondre aux questions des usagers, au détriment du traitement normal des demandes d’autorisation de travail. Avec WorkInFrance, en traitant simplement la plupart des demandes, nous libérerons du temps de travail pour les agents.
 
-De plus, l'administration est en charge de l'ensemble des instructions des demandes d'autorisation, en réceptionnant des demandes en format papier (CERFA et pièces justificatives obligatoires) obligeant celles-ci à stocker des volumes conséquents de documents, et posant de surcroît des difficultés pour accéder à un dossier « en cours ».
+De plus, l’administration est en charge de l’ensemble des instructions des demandes d’autorisation, en réceptionnant des demandes en format papier (CERFA et pièces justificatives obligatoires) obligeant celles-ci à stocker des volumes conséquents de documents, et posant de surcroît des difficultés pour accéder à un dossier « en cours ».
 
-### WorkinFrance, un service public transparent et adapté au rythme des entreprises
+**WorkinFrance, un service public transparent et adapté au rythme des entreprises**
 
-WorkInFrance simplifie la démarche d'autorisation de travail des étudiant·e·s en contrat d'apprentissage, en contrat de professionnalisation, les internes en médecine, et les étudiants algériens soumis à l'accord franco-algérien du 27 décembre 1968. Sur WorkinFrance, l'usager (entreprise ou salarié) trouvera une interface où déposer sa demande, avec une information sur l'état d'avancement de sa demande.
+WorkInFrance simplifie la démarche d’autorisation de travail des étudiantes et des étudiants en contrat d’apprentissage, en contrat de professionnalisation, les internes en médecine, et [les étudiants algériens soumis à l'accord franco-algérien du 27 décembre 1968](https://duckduckgo.com/?q=%C3%A9tudiants+alg%C3%A9riens&t=ffab&ia=web). Sur WorkinFrance, l'usager (entreprise ou salarié) trouvera une interface où déposer sa demande, avec une information sur l'état d'avancement de sa demande.
+
+
+<sup>1</sup> : Direction régionale des entreprises, de la concurrence, de la consommation, du travail et de l'emploi.
+
+<!-- end content -->
 
 <Timeline>
   <TimelineEvent

--- a/scripts/beta-sync.js
+++ b/scripts/beta-sync.js
@@ -1,0 +1,73 @@
+const fetch = require("node-fetch");
+const yaml = require("js-yaml");
+const fs = require("fs");
+
+const BETA_STARTUPS_URL =
+  process.env.BETA_STARTUPS_URL ||
+  "https://beta.gouv.fr/api/v2.1/startups.json";
+
+const readFile = (path) => fs.readFileSync(path, "utf8");
+const writeFile = (path, content) => fs.writeFileSync(path, content, "utf8");
+
+const socialStartups = yaml.safeLoad(readFile("./src/data/startups.yml"));
+
+const getBetaStartups = () =>
+  fetch(BETA_STARTUPS_URL)
+    .then((r) => r.json())
+    .then((r) => r.data);
+
+// handle special path cases
+function getSocialGouvPath(betaId) {
+  const startup = getSocialGouvStartup(betaId);
+  if (startup.page) {
+    return `./pages/startups/${startup.page}`;
+  }
+  return `./pages/startups/${startup.id}.mdx`;
+}
+
+// find social startup by betaId or id
+const getSocialGouvStartup = (betaId) =>
+  socialStartups.find((s) => (s.betaId || s.id) === betaId);
+
+const isSocialGouv = (startup) => !!getSocialGouvStartup(startup.id);
+
+// replace content in local startup mdx file
+function replaceStartupContent(betaId, content) {
+  const socialgouvPath = getSocialGouvPath(betaId);
+  const originalContent = readFile(socialgouvPath);
+  const replaceRegex = new RegExp(
+    "(<!-- start content -->)[\\s\\S]*(<!-- end content -->)",
+    "gm"
+  );
+  const newContent = originalContent.replace(
+    replaceRegex,
+    `$1\n\n${content.trim()}\n\n$2`
+  );
+  if (newContent !== originalContent) {
+    console.log(`Update startup ${betaId}`);
+    writeFile(socialgouvPath, newContent);
+  }
+}
+
+// update local startups contents
+async function sync() {
+  const betaStartups = await getBetaStartups();
+  const startups = betaStartups.filter(isSocialGouv);
+  startups.forEach((startup) => {
+    const markdown = decodeURIComponent(
+      startup.attributes.content_url_encoded_markdown
+    );
+    replaceStartupContent(startup.id, markdown);
+  });
+
+  // check if some missing on beta.gouv
+  socialStartups
+    .filter((s) => !betaStartups.find((a) => a.id === (s.betaId || s.id)))
+    .forEach((s) => {
+      console.error(`Startup ${s.id} not found on beta.gouv`);
+    });
+}
+
+if (require.main === module) {
+  sync().catch(console.error);
+}

--- a/src/data/startups.yml
+++ b/src/data/startups.yml
@@ -56,7 +56,7 @@
       description: Le code source de l'application eMJPM
 - id: code-du-travail-numerique
   betaId: codedutravail
-  page: code-du-travail-numerique/index.mdx
+  page: code-du-travail-numerique/index.mdx # permet de définir la page de la fiche produit si different de startups/[startup].mdx
   href: /startups/code-du-travail-numerique
   img: /images/startups/code-du-travail-numerique.jpg
   title: Code du travail numérique

--- a/src/data/startups.yml
+++ b/src/data/startups.yml
@@ -1,4 +1,5 @@
 - id: work-in-france
+  betaId: workinfrance
   href: /startups/work-in-france
   img: /images/startups/work-in-france.jpg
   title: Work In France
@@ -54,6 +55,8 @@
       href: https://github.com/SocialGouv/eMJPM
       description: Le code source de l'application eMJPM
 - id: code-du-travail-numerique
+  betaId: codedutravail
+  page: code-du-travail-numerique/index.mdx
   href: /startups/code-du-travail-numerique
   img: /images/startups/code-du-travail-numerique.jpg
   title: Code du travail numérique

--- a/src/data/startups.yml
+++ b/src/data/startups.yml
@@ -137,6 +137,7 @@
       href: https://github.com/SocialGouv/tremplin
       description: Bientôt ! Le code source de l'application Tremplin
 - id: egapro
+  betaId: egalite.professionnelle
   href: /startups/egapro
   img: /images/tim-mossholder-UcUROHSJfRA-unsplash.jpg
   title: Egapro


### PR DESCRIPTION
Synchronise les fiches produits depuis beta.gouv avec `yarn run beta-sync`

 - utilise https://beta.gouv.fr/api/v2.1/startups.json pour récupérer le markdown
 - se base sur notre `data/startup.yml` avec un optionnel `betaId` pour trouver la startup
 - remplace le contenu de `<!-- start content --> xxx <!-- end content -->` dans notre fiche produit

Startups manquantes chez beta : fce, mano, egapro, archifiltre, textstyle, monsuivipsy

Pour finaliser il faudrait reporter le contenu des startups ci-dessus sur le site de beta pour les récupérer de la même manière