### PR TITLE
fix(docker): use standard nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN yarn --production --frozen-lockfile --prefer-offline && yarn cache clean
 RUN yarn build
 RUN yarn export
 
-FROM ghcr.io/socialgouv/docker/nginx4spa:6.41.0
+FROM ghcr.io/socialgouv/docker/nginx:6.41.0
 
 COPY --from=builder /out /usr/share/nginx/html


### PR DESCRIPTION
the SPA image should be used only when we use client-side routing with a single index.html

(the spa image prevents 404 by always redirecting to index.html)