### PR TITLE
chore: set app pod requests and limits

### DIFF
--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -1,0 +1,10 @@
+app:
+  autoscale:
+    enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32M
+    limits:
+      cpu: 20m
+      memory: 64M

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -5,3 +5,12 @@ app:
     - www.incubateur.social.gouv.fr
     - incubateur.social.gouv.fr
     - fabrique.social.gouv.fr
+  autoscale:
+    enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32M
+    limits:
+      cpu: 40m
+      memory: 128M


### PR DESCRIPTION
The aim is to to fine tune `app` pod requests and limits on `preprod` and `prod` environments.

![](https://media.giphy.com/media/3o85xL32sNUfjqgqpa/giphy.gif)

Based on metrics given here:
- [preprod](https://grafana.fabrique.social.gouv.fr/d/x9tT8124z/kubernetes-v2-compute-resources-namespace-workloads-pod?orgId=1&refresh=10s&var-datasource=Thanos%20-%20Dev&var-cluster=dev2&var-namespace=www-preprod&var-type=deployment&from=now-7d&to=now)
- [prod](https://grafana.fabrique.social.gouv.fr/d/x9tT8124z/kubernetes-v2-compute-resources-namespace-workloads-pod?orgId=1&refresh=10s&var-datasource=Thanos%20-%20Prod&var-cluster=prod2&var-namespace=www&var-type=deployment&from=now-30d&to=now)